### PR TITLE
LTSVIEWER-321 Update Publish Package GHA Workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,35 @@
+name: Publish to npmjs on release
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on:
+      group: huit-arc
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compare the tag and version
+        run: |
+          NODE_VERSION=$(node -p -e "require('./package.json').version")
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          if [ "v$NODE_VERSION" != $LATEST_TAG ]; then echo "Github tag ($LATEST_TAG) and version ($NODE_VERSION) don't match" && exit 1; fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
**LTSVIEWER-321 Update Publish Package GHA Workflow**

---

**JIRA Ticket**: [LTSVIEWER-321](https://at-harvard.atlassian.net/browse/LTSVIEWER-321)

# What does this Pull Request do?

Update the publish package GHA workflow to a working version.

# How should this be tested?

The working run in the template repo can be found [here](https://github.com/harvard-lts/mirador-template-plugin/actions/runs/14870913722/job/41758918717).  Because this can only be tested as part of a release, the team agreed that this doesn't need to be tested until a release is actually necessary.

[LTSVIEWER-321]: https://at-harvard.atlassian.net/browse/LTSVIEWER-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ