### PR TITLE
LTSVIEWER-338 Update Base-x Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-url-sync-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-url-sync-plugin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "mirador": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "parcel": "^2.8.3",
+        "parcel": "^2.14.4",
         "url": "^0.11.0"
       }
     },
@@ -2808,22 +2808,22 @@
       ]
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.13.3.tgz",
-      "integrity": "sha512-mOuWeth0bZzRv1b9Lrvydis/hAzJyePy0gwa0tix3/zyYBvw0JY+xkXVR4qKyD/blc1Ra2qOlfI2uD3ucnsdXA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.14.4.tgz",
+      "integrity": "sha512-JVqi5Sb7wv2KCTJFAAjHbnl6KC61jKNVYw/GtZm5s/Wxqvxx2tcp93rmRoBFo9X3gSgkg8jp4HkNAUHTxnsPnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/graph": "3.3.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/graph": "3.4.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2831,15 +2831,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.13.3.tgz",
-      "integrity": "sha512-Vz5+K5uCt9mcuQAMDo0JdbPYDmVdB8Nvu/A2vTEK2rqZPxvoOTczKeMBA4JqzKqGURHPRLaJCvuR8nDG+jhK9A==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.14.4.tgz",
+      "integrity": "sha512-CTTMySgNSgcSwbNWL4gODU1h9hMjBRyiC8/gcKDFqzw0wC/T+ZwX7wc5zNc/S9aJRTmmgvndcYKoVlds7YV2sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/fs": "2.14.4",
+        "@parcel/logger": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "lmdb": "2.8.5"
       },
       "engines": {
@@ -2850,13 +2850,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.13.3.tgz",
-      "integrity": "sha512-L/PQf+PT0xM8k9nc0B+PxxOYO2phQYnbuifu9o4pFRiqVmCtHztP+XMIvRJ2gOEXy3pgAImSPFVJ3xGxMFky4g==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.14.4.tgz",
+      "integrity": "sha512-fRKkmFGnQIa/X+Kr8csTWjOwRRh2JfJfTpNS8JhbjBSWvOoKsDG9T2U5Ky8akIG7c9WDGwB3ngONauI1vtaInA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2888,17 +2888,17 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.13.3.tgz",
-      "integrity": "sha512-C6vjDlgTLjYc358i7LA/dqcL0XDQZ1IHXFw6hBaHHOfxPKW2T4bzUI6RURyToEK9Q1X7+ggDKqgdLxwp4veCFg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.14.4.tgz",
+      "integrity": "sha512-wYRdokznP1iI3n6M6leQ0nI65tCIWhZaD0vW3G3qodDFi+qsdpvZymCpNUkh6AYkFFr3Lur+r/+xkWDoqNoMWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2906,75 +2906,76 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.13.3.tgz",
-      "integrity": "sha512-WUsx83ic8DgLwwnL1Bua4lRgQqYjxiTT+DBxESGk1paNm1juWzyfPXEQDLXwiCTcWMQGiXQFQ8OuSISauVQ8dQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.14.4.tgz",
+      "integrity": "sha512-bHtr8yT2IZDv5w44/VKoNz07goidO99c6hsp9s0hjSVC1G6krdE+nriryPVfUFbw044LeQThSvA8EwTas72QZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/bundler-default": "2.13.3",
-        "@parcel/compressor-raw": "2.13.3",
-        "@parcel/namer-default": "2.13.3",
-        "@parcel/optimizer-css": "2.13.3",
-        "@parcel/optimizer-htmlnano": "2.13.3",
-        "@parcel/optimizer-image": "2.13.3",
-        "@parcel/optimizer-svgo": "2.13.3",
-        "@parcel/optimizer-swc": "2.13.3",
-        "@parcel/packager-css": "2.13.3",
-        "@parcel/packager-html": "2.13.3",
-        "@parcel/packager-js": "2.13.3",
-        "@parcel/packager-raw": "2.13.3",
-        "@parcel/packager-svg": "2.13.3",
-        "@parcel/packager-wasm": "2.13.3",
-        "@parcel/reporter-dev-server": "2.13.3",
-        "@parcel/resolver-default": "2.13.3",
-        "@parcel/runtime-browser-hmr": "2.13.3",
-        "@parcel/runtime-js": "2.13.3",
-        "@parcel/runtime-react-refresh": "2.13.3",
-        "@parcel/runtime-service-worker": "2.13.3",
-        "@parcel/transformer-babel": "2.13.3",
-        "@parcel/transformer-css": "2.13.3",
-        "@parcel/transformer-html": "2.13.3",
-        "@parcel/transformer-image": "2.13.3",
-        "@parcel/transformer-js": "2.13.3",
-        "@parcel/transformer-json": "2.13.3",
-        "@parcel/transformer-postcss": "2.13.3",
-        "@parcel/transformer-posthtml": "2.13.3",
-        "@parcel/transformer-raw": "2.13.3",
-        "@parcel/transformer-react-refresh-wrap": "2.13.3",
-        "@parcel/transformer-svg": "2.13.3"
+        "@parcel/bundler-default": "2.14.4",
+        "@parcel/compressor-raw": "2.14.4",
+        "@parcel/namer-default": "2.14.4",
+        "@parcel/optimizer-css": "2.14.4",
+        "@parcel/optimizer-htmlnano": "2.14.4",
+        "@parcel/optimizer-image": "2.14.4",
+        "@parcel/optimizer-svgo": "2.14.4",
+        "@parcel/optimizer-swc": "2.14.4",
+        "@parcel/packager-css": "2.14.4",
+        "@parcel/packager-html": "2.14.4",
+        "@parcel/packager-js": "2.14.4",
+        "@parcel/packager-raw": "2.14.4",
+        "@parcel/packager-svg": "2.14.4",
+        "@parcel/packager-wasm": "2.14.4",
+        "@parcel/reporter-dev-server": "2.14.4",
+        "@parcel/resolver-default": "2.14.4",
+        "@parcel/runtime-browser-hmr": "2.14.4",
+        "@parcel/runtime-js": "2.14.4",
+        "@parcel/runtime-rsc": "2.14.4",
+        "@parcel/runtime-service-worker": "2.14.4",
+        "@parcel/transformer-babel": "2.14.4",
+        "@parcel/transformer-css": "2.14.4",
+        "@parcel/transformer-html": "2.14.4",
+        "@parcel/transformer-image": "2.14.4",
+        "@parcel/transformer-js": "2.14.4",
+        "@parcel/transformer-json": "2.14.4",
+        "@parcel/transformer-node": "2.14.4",
+        "@parcel/transformer-postcss": "2.14.4",
+        "@parcel/transformer-posthtml": "2.14.4",
+        "@parcel/transformer-raw": "2.14.4",
+        "@parcel/transformer-react-refresh-wrap": "2.14.4",
+        "@parcel/transformer-svg": "2.14.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.13.3.tgz",
-      "integrity": "sha512-SRZFtqGiaKHlZ2YAvf+NHvBFWS3GnkBvJMfOJM7kxJRK3M1bhbwJa/GgSdzqro5UVf9Bfj6E+pkdrRQIOZ7jMQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.14.4.tgz",
+      "integrity": "sha512-dtUMmPDXd7CRAWwMlOc6jh6yLRL4wMi/vNMNdX9J/fafCLFgFBmPqWBhQ9tlX015Q8DEcIRWYPumHIn5dzqEbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/graph": "3.3.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/package-manager": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/profiler": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/cache": "2.14.4",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/events": "2.14.4",
+        "@parcel/feature-flags": "2.14.4",
+        "@parcel/fs": "2.14.4",
+        "@parcel/graph": "3.4.4",
+        "@parcel/logger": "2.14.4",
+        "@parcel/package-manager": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/profiler": "2.14.4",
+        "@parcel/rust": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/types": "2.14.4",
+        "@parcel/utils": "2.14.4",
+        "@parcel/workers": "2.14.4",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
@@ -2994,9 +2995,9 @@
       }
     },
     "node_modules/@parcel/core/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3007,9 +3008,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.13.3.tgz",
-      "integrity": "sha512-C70KXLBaXLJvr7XCEVu8m6TqNdw1gQLxqg5BQ8roR62R4vWWDnOq8PEksxDi4Y8Z/FF4i3Sapv6tRx9iBNxDEg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.14.4.tgz",
+      "integrity": "sha512-+pElcMMlTnpEIm9MrrSEOh38ylKYYdTYMgv2iZQU7799yzD9sSac9dkGSbbKGDYWhALCuzWQOgdaGG9ExJZw6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3024,10 +3025,24 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/error-overlay": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.14.4.tgz",
+      "integrity": "sha512-GZ6Z1XO/VYqIFNwa3iAYWX7Pskwd+xw9tPw9kjF7tG8wdL9VipkcILJ4APj/G5CKw8XrXH/6NsC7HndNbR7EqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/events": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.13.3.tgz",
-      "integrity": "sha512-ZkSHTTbD/E+53AjUzhAWTnMLnxLEU5yRw0H614CaruGh+GjgOIKyukGeToF5Gf/lvZ159VrJCGE0Z5EpgHVkuQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.14.4.tgz",
+      "integrity": "sha512-QzZr291JuENw7BsehKc3z29ukLMApPdjRFcOYXFuMWaHkpC7lzFK/KAY4Mi9HCa3aQe90zCcuxZg+bBsNF9XxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3039,9 +3054,9 @@
       }
     },
     "node_modules/@parcel/feature-flags": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.13.3.tgz",
-      "integrity": "sha512-UZm14QpamDFoUut9YtCZSpG1HxPs07lUwUCpsAYL0PpxASD3oWJQxIJGfDZPa2272DarXDG9adTKrNXvkHZblw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.14.4.tgz",
+      "integrity": "sha512-T2HE+lOmlU6PZOUnuXn6UZPXV4higCPgF2c2YXhrzTlSFcLMiAXATyzrylbYY/i/WjiYAlqvmEcaBX5fSaW95g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3053,18 +3068,18 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.13.3.tgz",
-      "integrity": "sha512-+MPWAt0zr+TCDSlj1LvkORTjfB/BSffsE99A9AvScKytDSYYpY2s0t4vtV9unSh0FHMS2aBCZNJ4t7KL+DcPIg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.14.4.tgz",
+      "integrity": "sha512-SQbuW6v1URv871FVj23HoC8+UUwpgkQ7iWmG7EITpp6AV42ojRr/jZ93hLjzkQQfYlRI64jUExn6AQAZDN3bqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/feature-flags": "2.14.4",
+        "@parcel/rust": "2.14.4",
+        "@parcel/types-internal": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.13.3"
+        "@parcel/workers": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -3074,17 +3089,17 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.3.3.tgz",
-      "integrity": "sha512-pxs4GauEdvCN8nRd6wG3st6LvpHske3GfqGwUSR0P0X0pBPI1/NicvXz6xzp3rgb9gPWfbKXeI/2IOTfIxxVfg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.4.4.tgz",
+      "integrity": "sha512-AIbJ8d8aCPcKAkqc45LENjAMIrp8nRGlmky5LyY5244qqnR1B+tsvU47XoGymM3OaXLdVjv8knJ4K0ci9/l/4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.13.3",
+        "@parcel/feature-flags": "2.14.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3096,14 +3111,14 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.13.3.tgz",
-      "integrity": "sha512-8YF/ZhsQgd7ohQ2vEqcMD1Ag9JlJULROWRPGgGYLGD+twuxAiSdiFBpN3f+j4gQN4PYaLaIS/SwUFx11J243fQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.14.4.tgz",
+      "integrity": "sha512-uqSGeCqraWpbe8gqbb1k9ePrlzdKoOwkdQPcRIv8TTTWZfCt6Qcl08w8didO4iAOz4H5C4Ng82wbVO/ieaMoKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3"
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/events": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -3114,9 +3129,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.13.3.tgz",
-      "integrity": "sha512-B4rUdlNUulJs2xOQuDbN7Hq5a9roq8IZUcJ1vQ8PAv+zMGb7KCfqIIr/BSCDYGhayfAGBVWW8x55Kvrl1zrDYw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.14.4.tgz",
+      "integrity": "sha512-B4787HHXHi0wcuYbV4qBibws/yaX4RXoNel5xWdwzn1ZFmeLAXluNjMO2Q6FmII/Lej9OIQEaTppl7/DxJGifg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3148,19 +3163,19 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.13.3.tgz",
-      "integrity": "sha512-A2a5A5fuyNcjSGOS0hPcdQmOE2kszZnLIXof7UMGNkNkeC62KAG8WcFZH5RNOY3LT5H773hq51zmc2Y2gE5Rnw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.14.4.tgz",
+      "integrity": "sha512-3FvZhkRgYlipj0NGRmw/rZ9ZiuM+a9ZcNW/MHRpytiNNBgcGCpR00XKhhvn0O5//MH13nLpiQXUf+J279CuN2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3168,17 +3183,17 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.4.3.tgz",
-      "integrity": "sha512-IEnMks49egEic1ITBp59VQyHzkSQUXqpU9hOHwqN3KoSTdZ6rEgrXcS3pa6tdXay4NYGlcZ88kFCE8i/xYoVCg==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.5.4.tgz",
+      "integrity": "sha512-KmmsVD8Ym+19DIbe0Y2SUbdcB+iUfgstR4dBpaogV36DlxV4d0uiia4GCpOO3kG9zlRYMVsfZEwy/NNZHELx3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/fs": "2.14.4",
+        "@parcel/rust": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -3191,9 +3206,9 @@
       }
     },
     "node_modules/@parcel/node-resolver-core/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3204,23 +3219,23 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.13.3.tgz",
-      "integrity": "sha512-A8o9IVCv919vhv69SkLmyW2WjJR5WZgcMqV6L1uiGF8i8z18myrMhrp2JuSHx29PRT9uNyzNC4Xrd4StYjIhJg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.14.4.tgz",
+      "integrity": "sha512-5rwwnsP8pnTqis5fs2YyNUvke6YprWlU8Y9pD55hK1Y1MbYmvCqaIyQv9lcpHJQiqrwsZ2pl5B3Ph5buDSQehQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.4",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3228,22 +3243,22 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.13.3.tgz",
-      "integrity": "sha512-K4Uvg0Sy2pECP7pdvvbud++F0pfcbNkq+IxTrgqBX5HJnLEmRZwgdvZEKF43oMEolclMnURMQRGjRplRaPdbXg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.14.4.tgz",
+      "integrity": "sha512-hLVaN7ResQcgKRo9uDm7oddC4DwR7qoTFsYn4Ftj8qGbgqB2nRpCCK0R66PA/9U98LyTOlAl1J6TEvxWR+IlKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3251,44 +3266,44 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.13.3.tgz",
-      "integrity": "sha512-wlDUICA29J4UnqkKrWiyt68g1e85qfYhp4zJFcFJL0LX1qqh1QwsLUz3YJ+KlruoqPxJSFEC8ncBEKiVCsqhEQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.14.4.tgz",
+      "integrity": "sha512-F5xw6ayFWOxu2XP5MI8g9khOCKNkVj4nGoXrBcgLoCKW4o07buCUKY4Sy04P3u7Leip6TOk7qpt3Q1179h6KTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3"
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
+        "@parcel/utils": "2.14.4",
+        "@parcel/workers": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.3.tgz",
-      "integrity": "sha512-piIKxQKzhZK54dJR6yqIcq+urZmpsfgUpLCZT3cnWlX4ux5+S2iN66qqZBs0zVn+a58LcWcoP4Z9ieiJmpiu2w==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.14.4.tgz",
+      "integrity": "sha512-bjZ2VHhzclBQ99SC2ZXsFKJ6zi0hXTPbGdaVblMu0iheeXcATdoNzey0eizaoSmLe9IyFJoN6gvnLdQqGfZLZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3296,22 +3311,22 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.13.3.tgz",
-      "integrity": "sha512-zNSq6oWqLlW8ksPIDjM0VgrK6ZAJbPQCDvs1V+p0oX3CzEe85lT5VkRpnfrN1+/vvEJNGL8e60efHKpI+rXGTA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.14.4.tgz",
+      "integrity": "sha512-7+p5ILEj2S02Rs6YzwF74g0kpAZzF9idDP9zjLVZWo9JYvoRvH0LW90bI7yKXWpKB8QOtwziqgWkcgItSIWBnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
-        "@swc/core": "^1.7.26",
+        "@parcel/utils": "2.14.4",
+        "@swc/core": "^1.11.5",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3319,20 +3334,20 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.13.3.tgz",
-      "integrity": "sha512-FLNI5OrZxymGf/Yln0E/kjnGn5sdkQAxW7pQVdtuM+5VeN75yibJRjsSGv88PvJ+KvpD2ANgiIJo1RufmoPcww==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.14.4.tgz",
+      "integrity": "sha512-chF2rBmLtLPZe0qtbqJtq6hNGCRu0+1wFs2j5sqxr1ZttvvhRpATu/7pD+gKTFmfL7iJkOpGTU485SYmyO1xjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/node-resolver-core": "3.4.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
-        "@swc/core": "^1.7.26",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/fs": "2.14.4",
+        "@parcel/logger": "2.14.4",
+        "@parcel/node-resolver-core": "3.5.4",
+        "@parcel/types": "2.14.4",
+        "@parcel/utils": "2.14.4",
+        "@parcel/workers": "2.14.4",
+        "@swc/core": "^1.11.5",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -3343,13 +3358,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@parcel/package-manager/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3360,22 +3375,22 @@
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.13.3.tgz",
-      "integrity": "sha512-ghDqRMtrUwaDERzFm9le0uz2PTeqqsjsW0ihQSZPSAptElRl9o5BR+XtMPv3r7Ui0evo+w35gD55oQCJ28vCig==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.14.4.tgz",
+      "integrity": "sha512-AvJhE1AQ4OcuOUtKoifhE1Y8KgYitzKMvmgsgQlwySdrkk6dz+XGHfZ9goTzIUaz9xZzwbJH7h/pvaIP8jQ9yQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.4",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3383,21 +3398,21 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.13.3.tgz",
-      "integrity": "sha512-jDLnKSA/EzVEZ3/aegXO3QJ/Ij732AgBBkIQfeC8tUoxwVz5b3HiPBAjVjcUSfZs7mdBSHO+ELWC3UD+HbsIrQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.14.4.tgz",
+      "integrity": "sha512-rsYz3NDaKRCuQOAWGc3eYJ2GHesm62iRCQTMGlZ7Oplp748vu2c1Uee/mP43WlslvDxHtV7rzVNyo88MS6sc5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/types": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3405,24 +3420,24 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.13.3.tgz",
-      "integrity": "sha512-0pMHHf2zOn7EOJe88QJw5h/wcV1bFfj6cXVcE55Wa8GX3V+SdCgolnlvNuBcRQ1Tlx0Xkpo+9hMFVIQbNQY6zw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.14.4.tgz",
+      "integrity": "sha512-Fz98TzYFcd9xCj6jqMtyd7c3n65GRmuoG7u0S/2g4sJrR5Zen70n1zlBGX7mEoOvB5lKRijzoNqBtB+7bWqS5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/types": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3459,17 +3474,17 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.13.3.tgz",
-      "integrity": "sha512-AWu4UB+akBdskzvT3KGVHIdacU9f7cI678DQQ1jKQuc9yZz5D0VFt3ocFBOmvDfEQDF0uH3jjtJR7fnuvX7Biw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.14.4.tgz",
+      "integrity": "sha512-7yDcPGsSSz4WiCWj2KoC2pNBXNislulI1RXaWyBAMzQhevQ+9D2ga/ZPgpcNjcWr8Y1tRb3QITETkTmZVHmPXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3477,20 +3492,20 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.13.3.tgz",
-      "integrity": "sha512-tKGRiFq/4jh5u2xpTstNQ7gu+RuZWzlWqpw5NaFmcKe6VQe5CMcS499xTFoREAGnRvevSeIgC38X1a+VOo+/AA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.14.4.tgz",
+      "integrity": "sha512-ja5P9PXp+v/mh+UXUXdQ1O35yr2kRqdRlytYrzmAaeILuS1ko2n3ZJoeUYYprYOh/UmLmkgbXh/DyzrhEH7TZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/types": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3498,17 +3513,17 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.13.3.tgz",
-      "integrity": "sha512-SZB56/b230vFrSehVXaUAWjJmWYc89gzb8OTLkBm7uvtFtov2J1R8Ig9TTJwinyXE3h84MCFP/YpQElSfoLkJw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.14.4.tgz",
+      "integrity": "sha512-sgGCitPjl80Ku+xZIu3wCIAjOYXVEGJ00uXeexR8hgMx/PMhiHXLWUG8eLYAvxXx/CcLmHDOEBNrl6G3JxsP9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.4"
       },
       "engines": {
         "node": ">=16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3516,13 +3531,13 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.13.3.tgz",
-      "integrity": "sha512-cterKHHcwg6q11Gpif/aqvHo056TR+yDVJ3fSdiG2xr5KD1VZ2B3hmofWERNNwjMcnR1h9Xq40B7jCKUhOyNFA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.14.4.tgz",
+      "integrity": "sha512-EcehbthkBtQ9S2jWAzIiSlodbIMZ0bSsN3PC1q9jVaCM16ueObjZohKkzMjzR6Qot91qL0EJoMLzuNvtryvpHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types": "2.13.3"
+        "@parcel/types": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -3533,15 +3548,15 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.13.3.tgz",
-      "integrity": "sha512-ok6BwWSLvyHe5TuSXjSacYnDStFgP5Y30tA9mbtWSm0INDsYf+m5DqzpYPx8U54OaywWMK8w3MXUClosJX3aPA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.14.4.tgz",
+      "integrity": "sha512-oZAdCDW3bYRpBOuL4coq4OQDN6HXADaSd4X8xJCeGsEsbVfJt0Qg5RgxdWC1L86mukyZMQ9ZrQUpC8aU9CAmFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/events": "2.14.4",
+        "@parcel/types-internal": "2.14.4",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -3553,21 +3568,21 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.13.3.tgz",
-      "integrity": "sha512-EA5tKt/6bXYNMEavSs35qHlFdx6cZmRazlZxPBgxPePQYoouNAPMNLUOEQozaPhz9f5fvNDN7EHOFaAWcdO2LA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.14.4.tgz",
+      "integrity": "sha512-KgBXBiwGb9hqf3A6vw6eIqX1uYaMRjSqYXUUybGTOxonc+yB6J5q+skv1Wuty6IYuBfjNlV/zdvgggVZMl0ZxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/types": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/types": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3592,18 +3607,20 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.13.3.tgz",
-      "integrity": "sha512-ZNeFp6AOIQFv7mZIv2P5O188dnZHNg0ymeDVcakfZomwhpSva2dFNS3AnvWo4eyWBlUxkmQO8BtaxeWTs7jAuA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.14.4.tgz",
+      "integrity": "sha512-Ezg24vHftV0El0tWcxnsGAxwSdNTMs9M+l9Nbm1k4rydx1lCoKBAhpa2Icv8vKZY8K075giww8TOkjk6zVkAmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/codeframe": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3611,20 +3628,20 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.13.3.tgz",
-      "integrity": "sha512-aBsVPI8jLZTDkFYrI69GxnsdvZKEYerkPsu935LcX9rfUYssOnmmUP+3oI+8fbg+qNjJuk9BgoQ4hCp9FOphMQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.14.4.tgz",
+      "integrity": "sha512-EN+rzdEnoMuC5qbYIcuP6v1vTb/dDPrrnIEtDFEsSyuBuDfQevtOech8oHzjGEBOlC8svm+OzW/wIj2L2rmF2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3632,18 +3649,18 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.13.3.tgz",
-      "integrity": "sha512-urBZuRALWT9pFMeWQ8JirchLmsQEyI9lrJptiwLbJWrwvmlwSUGkcstmPwoNRf/aAQjICB7ser/247Vny0pFxA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.14.4.tgz",
+      "integrity": "sha512-s4XKnfScF/cwqGyYG/sB4WpktIJ55dvpu64ZiglHkkPvY5wT4p7A61mTIp6ck0ZPYmeG/zfd+P0B3qPpNF5mUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/node-resolver-core": "3.4.3",
-        "@parcel/plugin": "2.13.3"
+        "@parcel/node-resolver-core": "3.5.4",
+        "@parcel/plugin": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3651,18 +3668,18 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.13.3.tgz",
-      "integrity": "sha512-EAcPojQFUNUGUrDk66cu3ySPO0NXRVS5CKPd4QrxPCVVbGzde4koKu8krC/TaGsoyUqhie8HMnS70qBP0GFfcQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.14.4.tgz",
+      "integrity": "sha512-7o3XHOkuNy2jUH8xdKJSzIfatdAqvr/PHg9vQN0Cz4r80XCXDh1ovfz/x0Q9gpBv+LMBs+ufZ4tP+RfgJ/jKpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3"
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3670,41 +3687,41 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.13.3.tgz",
-      "integrity": "sha512-62OucNAnxb2Q0uyTFWW/0Hvv2DJ4b5H6neh/YFu2/wmxaZ37xTpEuEcG2do7KW54xE5DeLP+RliHLwi4NvR3ww==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.14.4.tgz",
+      "integrity": "sha512-F9RvDELU/0fyV2/rHkjpPcLeKF/ZU3gnHIQnkh2Q5/41XhymyNAvMmYGPM6VpbOAnDlYeVjwfyJ41x8FOL6u4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.13.3.tgz",
-      "integrity": "sha512-PYZ1klpJVwqE3WuifILjtF1dugtesHEuJcXYZI85T6UoRSD5ctS1nAIpZzT14Ga1lRt/jd+eAmhWL1l3m/Vk1Q==",
+    "node_modules/@parcel/runtime-rsc": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.14.4.tgz",
+      "integrity": "sha512-FXoO1GWvC/yQOUYX+0rTUQVku91DSJnjegqJaiJSUOEGeJWF9mBmY/3QDkksvhwB25vJkLYsu/M5Fx83OA2u6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "react-error-overlay": "6.0.9",
-        "react-refresh": ">=0.9 <=0.14"
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
+        "@parcel/utils": "2.14.4",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "node": ">= 12.0.0",
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3712,19 +3729,19 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3.tgz",
-      "integrity": "sha512-BjMhPuT7Us1+YIo31exPRwomPiL+jrZZS5UUAwlEW2XGHDceEotzRM94LwxeFliCScT4IOokGoxixm19qRuzWg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.14.4.tgz",
+      "integrity": "sha512-6+vz2DYP9tK+GHRPwW/qfUNvGOHvFpsN/Thk+tSIZ+PHT1DTWfpf02eo7fzpImdZAzllSz3m1IXgrOH00LdOKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3732,9 +3749,9 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.13.3.tgz",
-      "integrity": "sha512-dLq85xDAtzr3P5200cvxk+8WXSWauYbxuev9LCPdwfhlaWo/JEj6cu9seVdWlkagjGwkoV1kXC+GGntgUXOLAQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.14.4.tgz",
+      "integrity": "sha512-Ti+ZVr8mMTgrSA7UHcFXxG98anD0C8dGzYfP1+DTgxkcU16nywTv5F/VsPqpV2qiDWrHbm06CEWQbOrowjzvVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3743,6 +3760,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "napi-wasm": "^1.1.2"
+      },
+      "peerDependenciesMeta": {
+        "napi-wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@parcel/source-map": {
@@ -3759,16 +3784,16 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.13.3.tgz",
-      "integrity": "sha512-ikzK9f5WTFrdQsPitQgjCPH6HmVU8AQPRemIJ2BndYhtodn5PQut5cnSvTrqax8RjYvheEKCQk/Zb/uR7qgS3g==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.14.4.tgz",
+      "integrity": "sha512-9yMnlFuKQYgXJY8OWpcR2vSigpMm5MCEJJl6r+g3KkXHFwK1Gket2sC4Wd5JbHv98SNzJ9rdD4Xrre/eXJu6pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.4",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -3776,7 +3801,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3784,9 +3809,9 @@
       }
     },
     "node_modules/@parcel/transformer-babel/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3797,23 +3822,23 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.13.3.tgz",
-      "integrity": "sha512-zbrNURGph6JeVADbGydyZ7lcu/izj41kDxQ9xw4RPRW/3rofQiTU0OTREi+uBWiMENQySXVivEdzHA9cA+aLAA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.14.4.tgz",
+      "integrity": "sha512-sf0NuzPH4kSpL4VgV94xY5kPxoAndoNouUFPaHmN3hW6QiTHShRubfDsginSOHl5QhghSfr4qtP7t7HxCSDq6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
+        "@parcel/utils": "2.14.4",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3821,15 +3846,15 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.13.3.tgz",
-      "integrity": "sha512-Yf74FkL9RCCB4+hxQRVMNQThH9+fZ5w0NLiQPpWUOcgDEEyxTi4FWPQgEBsKl/XK2ehdydbQB9fBgPQLuQxwPg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.14.4.tgz",
+      "integrity": "sha512-h0iCfU2SN+gh5LTfZTRiXHavl3CdJ2i3F9jzVrRjdH8pfLqy5eOy1tQ8vyqMsshk+VdlZ1+vUiZ7uaKkkBq/fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -3839,7 +3864,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3847,9 +3872,9 @@
       }
     },
     "node_modules/@parcel/transformer-html/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3873,38 +3898,38 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.13.3.tgz",
-      "integrity": "sha512-wL1CXyeFAqbp2wcEq/JD3a/tbAyVIDMTC6laQxlIwnVV7dsENhK1qRuJZuoBdixESeUpFQSmmQvDIhcfT/cUUg==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.14.4.tgz",
+      "integrity": "sha512-QVGAdQ16YxNo7PTzBazUabmrn4dss1EDeMrh0bFUeRTZdYaYu5z/+gnRc5R4oHcHK6oxnECi808TquMQcQxDEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4",
+        "@parcel/workers": "2.14.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.13.3.tgz",
-      "integrity": "sha512-KqfNGn1IHzDoN2aPqt4nDksgb50Xzcny777C7A7hjlQ3cmkjyJrixYjzzsPaPSGJ+kJpknh3KE8unkQ9mhFvRQ==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.14.4.tgz",
+      "integrity": "sha512-fBC8NVM8xXxjGQY5r88Z46akSErFO5hRVA4kuRI0tkXorjov3Mu4hu6MLq974TEQluSvGXUYGT5Mq2iXZ75M7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.3",
-        "@parcel/workers": "2.13.3",
+        "@parcel/utils": "2.14.4",
+        "@parcel/workers": "2.14.4",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -3913,20 +3938,20 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@parcel/transformer-js/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3937,18 +3962,36 @@
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.13.3.tgz",
-      "integrity": "sha512-rrq0ab6J0w9ePtsxi0kAvpCmrUYXXAx1Z5PATZakv89rSYbHBKEdXxyCoKFui/UPVCUEGVs5r0iOFepdHpIyeA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.14.4.tgz",
+      "integrity": "sha512-+28n3/qhc2q6Zoqhufk1YKU442a2JyyE0ILFsT17Of+lcNX+QtXYPOYcky7TNENnoUz9TpOAFev64P99UN7huA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
+        "@parcel/plugin": "2.14.4",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/transformer-node": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.14.4.tgz",
+      "integrity": "sha512-K5k/GkGN4SwGdil8g10AcPPJn+hV0vzcv4l2qYoCqaxxIPCrpjmMnoA8a3kRgxvD8s54KciFYYjmU5Cj5NjvbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/plugin": "2.14.4"
+      },
+      "engines": {
+        "node": ">= 16.0.0",
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3956,16 +3999,16 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.13.3.tgz",
-      "integrity": "sha512-AIiWpU0QSFBrPcYIqAnhqB8RGE6yHFznnxztfg1t2zMSOnK3xoU6xqYKv8H/MduShGGrC3qVOeDfM8MUwzL3cw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.14.4.tgz",
+      "integrity": "sha512-GxkXkcgG2XGt6ivoUF5yD1tmQPV+d71gUxyBGv1i1jg4x65R12Gc/npzWk9TCH2dShSdHOA90OJpNL4k0JlLtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -3973,7 +4016,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -3981,9 +4024,9 @@
       }
     },
     "node_modules/@parcel/transformer-postcss/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3994,14 +4037,14 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.13.3.tgz",
-      "integrity": "sha512-5GSLyccpHASwFAu3uJ83gDIBSvfsGdVmhJvy0Vxe+K1Fklk2ibhvvtUHMhB7mg6SPHC+R9jsNc3ZqY04ZLeGjw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.14.4.tgz",
+      "integrity": "sha512-V9dnsA5+t7uF/hWc9HwJcaKkmP8K2go6yAQOpxu+knyszfz3t2jw/k4L/VFjqCATf90agal/iRTPVkHvWDCzZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -4010,7 +4053,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -4018,9 +4061,9 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4031,17 +4074,17 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.13.3.tgz",
-      "integrity": "sha512-BFsAbdQF0l8/Pdb7dSLJeYcd8jgwvAUbHgMink2MNXJuRUvDl19Gns8jVokU+uraFHulJMBj40+K/RTd33in4g==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.14.4.tgz",
+      "integrity": "sha512-GCuUWKAb9YHB/krmzBeQbtHKKZopT3c3AzoPTq/4woV4Ti1zUZ83oFyTX1tBKQ+MMB1BW+HrPkFld0iY4gp/Ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3"
+        "@parcel/plugin": "2.14.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -4049,19 +4092,20 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.13.3.tgz",
-      "integrity": "sha512-mOof4cRyxsZRdg8kkWaFtaX98mHpxUhcGPU+nF9RQVa9q737ItxrorsPNR9hpZAyE2TtFNflNW7RoYsgvlLw8w==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.14.4.tgz",
+      "integrity": "sha512-nb70CAvjDizAIQ1naZ39P/PxYWtPllWvvxrkpldNnk8AF74OcHodrsuHKwhyPZHMmnMdexFonsenf+VeN4l/aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.3",
-        "@parcel/utils": "2.13.3",
-        "react-refresh": ">=0.9 <=0.14"
+        "@parcel/error-overlay": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/utils": "2.14.4",
+        "react-refresh": ">=0.9 <=0.16"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -4069,15 +4113,15 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.13.3.tgz",
-      "integrity": "sha512-9jm7ZF4KHIrGLWlw/SFUz5KKJ20nxHvjFAmzde34R9Wu+F1BOjLZxae7w4ZRwvIc+UVOUcBBQFmhSVwVDZg6Dw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.14.4.tgz",
+      "integrity": "sha512-iqnyvgGmwu4wNh+khEBkMEu1hAGZWnc7/xQnhiuQBAcoy5qGNEjyVUv6PbMLWWAVK/0PjqV4FaB2deXBYKeW0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/plugin": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/plugin": "2.14.4",
+        "@parcel/rust": "2.14.4",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -4086,7 +4130,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.3"
+        "parcel": "^2.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -4094,9 +4138,9 @@
       }
     },
     "node_modules/@parcel/transformer-svg/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4107,41 +4151,41 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.13.3.tgz",
-      "integrity": "sha512-+RpFHxx8fy8/dpuehHUw/ja9PRExC3wJoIlIIF42E7SLu2SvlTHtKm6EfICZzxCXNEBzjoDbamCRcN0nmTPlhw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.14.4.tgz",
+      "integrity": "sha512-NL4N9M6IPwBquAo1DKOPqy66nwJLXMX3KPalzAA7ktt3HYr5YNG5h3GeVXPOLNIVVMrSIiodYGPEeEBYy6kyYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/workers": "2.13.3"
+        "@parcel/types-internal": "2.14.4",
+        "@parcel/workers": "2.14.4"
       }
     },
     "node_modules/@parcel/types-internal": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.13.3.tgz",
-      "integrity": "sha512-Lhx0n+9RCp+Ipktf/I+CLm3zE9Iq9NtDd8b2Vr5lVWyoT8AbzBKIHIpTbhLS4kjZ80L3I6o93OYjqAaIjsqoZw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.14.4.tgz",
+      "integrity": "sha512-Y2JnljFG7KcxLrCiYNCqBfjDo12alhRVpNugm0jwz1EQ3OQNO3HYiB0f3djq6pv2clZ5ndpgkNgYsn6L7KR9Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/feature-flags": "2.14.4",
         "@parcel/source-map": "^2.1.1",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.13.3.tgz",
-      "integrity": "sha512-yxY9xw2wOUlJaScOXYZmMGoZ4Ck4Kqj+p6Koe5kLkkWM1j98Q0Dj2tf/mNvZi4yrdnlm+dclCwNRnuE8Q9D+pw==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.14.4.tgz",
+      "integrity": "sha512-icK6QgKjis+UZLyaHJcsKXYOSKYeYr41m8ZB9j20/yEcvrMqj/LMVsNjLz3iWVhLwfgussG2ODxycCdu3M5cvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/codeframe": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/markdown-ansi": "2.13.3",
-        "@parcel/rust": "2.13.3",
+        "@parcel/codeframe": "2.14.4",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/logger": "2.14.4",
+        "@parcel/markdown-ansi": "2.14.4",
+        "@parcel/rust": "2.14.4",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
@@ -4172,9 +4216,9 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4192,25 +4236,25 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.0",
-        "@parcel/watcher-darwin-arm64": "2.5.0",
-        "@parcel/watcher-darwin-x64": "2.5.0",
-        "@parcel/watcher-freebsd-x64": "2.5.0",
-        "@parcel/watcher-linux-arm-glibc": "2.5.0",
-        "@parcel/watcher-linux-arm-musl": "2.5.0",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.0",
-        "@parcel/watcher-linux-arm64-musl": "2.5.0",
-        "@parcel/watcher-linux-x64-glibc": "2.5.0",
-        "@parcel/watcher-linux-x64-musl": "2.5.0",
-        "@parcel/watcher-win32-arm64": "2.5.0",
-        "@parcel/watcher-win32-ia32": "2.5.0",
-        "@parcel/watcher-win32-x64": "2.5.0"
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
-      "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
       "cpu": [
         "arm64"
       ],
@@ -4229,9 +4273,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
-      "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
       "cpu": [
         "arm64"
       ],
@@ -4250,9 +4294,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
-      "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
       "cpu": [
         "x64"
       ],
@@ -4271,9 +4315,9 @@
       }
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
-      "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
       "cpu": [
         "x64"
       ],
@@ -4292,9 +4336,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
-      "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
       "cpu": [
         "arm"
       ],
@@ -4313,9 +4357,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
-      "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
       "cpu": [
         "arm"
       ],
@@ -4334,9 +4378,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
-      "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
       "cpu": [
         "arm64"
       ],
@@ -4355,9 +4399,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
-      "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
       "cpu": [
         "arm64"
       ],
@@ -4376,9 +4420,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
-      "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
       "cpu": [
         "x64"
       ],
@@ -4397,9 +4441,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
-      "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
       "cpu": [
         "x64"
       ],
@@ -4418,9 +4462,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
-      "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
       "cpu": [
         "arm64"
       ],
@@ -4439,9 +4483,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
-      "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
       "cpu": [
         "ia32"
       ],
@@ -4460,9 +4504,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
-      "integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
       "cpu": [
         "x64"
       ],
@@ -4481,17 +4525,17 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.13.3.tgz",
-      "integrity": "sha512-oAHmdniWTRwwwsKbcF4t3VjOtKN+/W17Wj5laiYB+HLkfsjGTfIQPj3sdXmrlBAGpI4omIcvR70PHHXnfdTfwA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.14.4.tgz",
+      "integrity": "sha512-OAjW2dJOaRKy4UD5YwnUi7mY+gt/QbjagjrKh2fQDnrvuK8dpr5GrjEOLOe6QsxEE0vpe3jshhGMJTYqLni3kQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/profiler": "2.13.3",
-        "@parcel/types-internal": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/logger": "2.14.4",
+        "@parcel/profiler": "2.14.4",
+        "@parcel/types-internal": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -4502,7 +4546,7 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.3"
+        "@parcel/core": "^2.14.4"
       }
     },
     "node_modules/@react-dnd/asap": {
@@ -4620,15 +4664,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.9.tgz",
-      "integrity": "sha512-MQ97YSXu2oibzm7wi4GNa7hhndjLuVt/lmO2sq53+P37oZmyg/JQ/IYYtSiC6UGK3+cHoiVAykrK+glxLjJbag==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.29.tgz",
+      "integrity": "sha512-g4mThMIpWbNhV8G2rWp5a5/Igv8/2UFRJx2yImrLGMgrDDYZIopqZ/z0jZxDgqNA1QDx93rpwNF7jGsxVWcMlA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.17"
+        "@swc/types": "^0.1.21"
       },
       "engines": {
         "node": ">=10"
@@ -4638,19 +4682,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.10.9",
-        "@swc/core-darwin-x64": "1.10.9",
-        "@swc/core-linux-arm-gnueabihf": "1.10.9",
-        "@swc/core-linux-arm64-gnu": "1.10.9",
-        "@swc/core-linux-arm64-musl": "1.10.9",
-        "@swc/core-linux-x64-gnu": "1.10.9",
-        "@swc/core-linux-x64-musl": "1.10.9",
-        "@swc/core-win32-arm64-msvc": "1.10.9",
-        "@swc/core-win32-ia32-msvc": "1.10.9",
-        "@swc/core-win32-x64-msvc": "1.10.9"
+        "@swc/core-darwin-arm64": "1.11.29",
+        "@swc/core-darwin-x64": "1.11.29",
+        "@swc/core-linux-arm-gnueabihf": "1.11.29",
+        "@swc/core-linux-arm64-gnu": "1.11.29",
+        "@swc/core-linux-arm64-musl": "1.11.29",
+        "@swc/core-linux-x64-gnu": "1.11.29",
+        "@swc/core-linux-x64-musl": "1.11.29",
+        "@swc/core-win32-arm64-msvc": "1.11.29",
+        "@swc/core-win32-ia32-msvc": "1.11.29",
+        "@swc/core-win32-x64-msvc": "1.11.29"
       },
       "peerDependencies": {
-        "@swc/helpers": "*"
+        "@swc/helpers": ">=0.5.17"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -4659,9 +4703,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.9.tgz",
-      "integrity": "sha512-XTHLtijFervv2B+i1ngM993umhSj9K1IeMomvU/Db84Asjur2XmD4KXt9QPnGDRFgv2kLSjZ+DDL25Qk0f4r+w==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.29.tgz",
+      "integrity": "sha512-whsCX7URzbuS5aET58c75Dloby3Gtj/ITk2vc4WW6pSDQKSPDuONsIcZ7B2ng8oz0K6ttbi4p3H/PNPQLJ4maQ==",
       "cpu": [
         "arm64"
       ],
@@ -4676,9 +4720,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.9.tgz",
-      "integrity": "sha512-bi3el9/FV/la8HIsolSjeDar+tM7m9AmSF1w7X6ZByW2qgc4Z1tmq0A4M4H9aH3TfHesZbfq8hgaNtc2/VtzzQ==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.29.tgz",
+      "integrity": "sha512-S3eTo/KYFk+76cWJRgX30hylN5XkSmjYtCBnM4jPLYn7L6zWYEPajsFLmruQEiTEDUg0gBEWLMNyUeghtswouw==",
       "cpu": [
         "x64"
       ],
@@ -4693,9 +4737,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.9.tgz",
-      "integrity": "sha512-xsLHV02S+RTDuI+UJBkA2muNk/s0ETRpoc1K/gNt0i8BqTurPYkrvGDDALN9+leiUPydHvZi9P1qdExbgUJnXw==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.29.tgz",
+      "integrity": "sha512-o9gdshbzkUMG6azldHdmKklcfrcMx+a23d/2qHQHPDLUPAN+Trd+sDQUYArK5Fcm7TlpG4sczz95ghN0DMkM7g==",
       "cpu": [
         "arm"
       ],
@@ -4710,9 +4754,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.9.tgz",
-      "integrity": "sha512-41hJgPoGhIa12U6Tud+yLF/m64YA3mGut3TmBEkj2R7rdJdE0mljdtR0tf4J2RoQaWZPPi0DBSqGdROiAEx9dg==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.29.tgz",
+      "integrity": "sha512-sLoaciOgUKQF1KX9T6hPGzvhOQaJn+3DHy4LOHeXhQqvBgr+7QcZ+hl4uixPKTzxk6hy6Hb0QOvQEdBAAR1gXw==",
       "cpu": [
         "arm64"
       ],
@@ -4727,9 +4771,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.9.tgz",
-      "integrity": "sha512-DUMRhl49b9r7bLg9oNzCdW4lLcDJKrRBn87Iq5APPvixsm1auGnsVQycGkQcDDKvVllxIFSbmCYzjagx3l8Hnw==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.29.tgz",
+      "integrity": "sha512-PwjB10BC0N+Ce7RU/L23eYch6lXFHz7r3NFavIcwDNa/AAqywfxyxh13OeRy+P0cg7NDpWEETWspXeI4Ek8otw==",
       "cpu": [
         "arm64"
       ],
@@ -4744,9 +4788,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.9.tgz",
-      "integrity": "sha512-xW0y88vQvmzYo3Gn7yFnY03TfHMwuca4aFH3ZmhwDNOYHmTOi6fmhAkg/13F/NrwjMYO+GnF5uJTjdjb3B6tdQ==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.29.tgz",
+      "integrity": "sha512-i62vBVoPaVe9A3mc6gJG07n0/e7FVeAvdD9uzZTtGLiuIfVfIBta8EMquzvf+POLycSk79Z6lRhGPZPJPYiQaA==",
       "cpu": [
         "x64"
       ],
@@ -4761,9 +4805,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.9.tgz",
-      "integrity": "sha512-jYs32BEx+CPVuxN6NdsWEpdehjnmAag25jyJzwjQx+NCGYwHEV3bT5y8TX4eFhaVB1rafmqJOlYQPs4+MSyGCg==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.29.tgz",
+      "integrity": "sha512-YER0XU1xqFdK0hKkfSVX1YIyCvMDI7K07GIpefPvcfyNGs38AXKhb2byySDjbVxkdl4dycaxxhRyhQ2gKSlsFQ==",
       "cpu": [
         "x64"
       ],
@@ -4778,9 +4822,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.9.tgz",
-      "integrity": "sha512-Uhh5T3Fq3Nyom96Bm3ACBNASH3iqNc76in7ewZz8PooUqeTIO8aZpsghnncjctRNE9T819/8btpiFIhHo3sKtg==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.29.tgz",
+      "integrity": "sha512-po+WHw+k9g6FAg5IJ+sMwtA/fIUL3zPQ4m/uJgONBATCVnDDkyW6dBA49uHNVtSEvjvhuD8DVWdFP847YTcITw==",
       "cpu": [
         "arm64"
       ],
@@ -4795,9 +4839,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.9.tgz",
-      "integrity": "sha512-bD5BpbojEsDfrAvT+1qjQPf5RCKLg4UL+3Uwm019+ZR02hd8qO538BlOnQdOqRqccu+75DF6aRglQ7AJ24Cs0Q==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.29.tgz",
+      "integrity": "sha512-h+NjOrbqdRBYr5ItmStmQt6x3tnhqgwbj9YxdGPepbTDamFv7vFnhZR0YfB3jz3UKJ8H3uGJ65Zw1VsC+xpFkg==",
       "cpu": [
         "ia32"
       ],
@@ -4812,9 +4856,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.9.tgz",
-      "integrity": "sha512-NwkuUNeBBQnAaXVvcGw8Zr6RR8kylyjFUnlYZZ3G0QkQZ4rYLXYTafAmiRjrfzgVb0LcMF/sBzJvGOk7SwtIDg==",
+      "version": "1.11.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.29.tgz",
+      "integrity": "sha512-Q8cs2BDV9wqDvqobkXOYdC+pLUSEpX/KvI0Dgfun1F+LzuLotRFuDhrvkU9ETJA6OnD2+Fn/ieHgloiKA/Mn/g==",
       "cpu": [
         "x64"
       ],
@@ -4836,9 +4880,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4846,9 +4890,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5556,9 +5600,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6381,9 +6425,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -7057,20 +7101,19 @@
       }
     },
     "node_modules/htmlnano": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.1.tgz",
-      "integrity": "sha512-kAERyg/LuNZYmdqgCdYvugyLWNFAm8MWXpQMz1pLpetmCbFwoMxvkSoaAMlFrOC4OKTWI4KlZGT/RsNxg4ghOw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.2.tgz",
+      "integrity": "sha512-8Fst+0bhAfU362S6oHVb4wtJj/UYEFr0qiCLAEi8zioqmp1JYBQx5crZAADlFVX0Ly/6s/IQz6G7PL9/hgoJaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cosmiconfig": "^9.0.0",
-        "posthtml": "^0.16.5",
-        "timsort": "^0.3.0"
+        "posthtml": "^0.16.5"
       },
       "peerDependencies": {
         "cssnano": "^7.0.0",
         "postcss": "^8.3.11",
-        "purgecss": "^6.0.0",
+        "purgecss": "^7.0.2",
         "relateurl": "^0.2.7",
         "srcset": "5.0.1",
         "svgo": "^3.0.2",
@@ -7210,9 +7253,9 @@
       "license": "MIT"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9169,13 +9212,13 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
-      "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -9185,22 +9228,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.29.1",
-        "lightningcss-darwin-x64": "1.29.1",
-        "lightningcss-freebsd-x64": "1.29.1",
-        "lightningcss-linux-arm-gnueabihf": "1.29.1",
-        "lightningcss-linux-arm64-gnu": "1.29.1",
-        "lightningcss-linux-arm64-musl": "1.29.1",
-        "lightningcss-linux-x64-gnu": "1.29.1",
-        "lightningcss-linux-x64-musl": "1.29.1",
-        "lightningcss-win32-arm64-msvc": "1.29.1",
-        "lightningcss-win32-x64-msvc": "1.29.1"
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
-      "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
       "cpu": [
         "arm64"
       ],
@@ -9219,9 +9262,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.1.tgz",
-      "integrity": "sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
       "cpu": [
         "x64"
       ],
@@ -9240,9 +9283,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.1.tgz",
-      "integrity": "sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
       "cpu": [
         "x64"
       ],
@@ -9261,9 +9304,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.1.tgz",
-      "integrity": "sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
       "cpu": [
         "arm"
       ],
@@ -9282,9 +9325,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
-      "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
       "cpu": [
         "arm64"
       ],
@@ -9303,9 +9346,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.1.tgz",
-      "integrity": "sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
       "cpu": [
         "arm64"
       ],
@@ -9324,9 +9367,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
-      "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
       "cpu": [
         "x64"
       ],
@@ -9345,9 +9388,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.1.tgz",
-      "integrity": "sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
       "cpu": [
         "x64"
       ],
@@ -9366,9 +9409,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.1.tgz",
-      "integrity": "sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
       "cpu": [
         "arm64"
       ],
@@ -9387,9 +9430,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.1.tgz",
-      "integrity": "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
       "cpu": [
         "x64"
       ],
@@ -9405,6 +9448,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lines-and-columns": {
@@ -9716,9 +9769,9 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.2.tgz",
-      "integrity": "sha512-F9UngXRlPyWCDEASDpTf6c9uNhGPTqnTeLVt7bN+bU1eajoR/8V9ys2BRaV5C/e5ihE6sJ9uPIKaYt6bFuO32g==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
+      "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -9749,9 +9802,9 @@
       }
     },
     "node_modules/msgpackr-extract/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -9847,9 +9900,9 @@
       }
     },
     "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -10084,24 +10137,24 @@
       }
     },
     "node_modules/parcel": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.13.3.tgz",
-      "integrity": "sha512-8GrC8C7J8mwRpAlk7EJ7lwdFTbCN+dcXH2gy5AsEs9pLfzo9wvxOTx6W0fzSlvCOvZOita+8GdfYlGfEt0tRgA==",
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.14.4.tgz",
+      "integrity": "sha512-XmnIurC4CPdQm9OFJMbjgvto5Jz2szZ5/p6EY4pAljU/SLPhtBzJ3+J6OyljGFdbVxEXx4dp+7Cvf7eaDZsEEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/config-default": "2.13.3",
-        "@parcel/core": "2.13.3",
-        "@parcel/diagnostic": "2.13.3",
-        "@parcel/events": "2.13.3",
-        "@parcel/feature-flags": "2.13.3",
-        "@parcel/fs": "2.13.3",
-        "@parcel/logger": "2.13.3",
-        "@parcel/package-manager": "2.13.3",
-        "@parcel/reporter-cli": "2.13.3",
-        "@parcel/reporter-dev-server": "2.13.3",
-        "@parcel/reporter-tracer": "2.13.3",
-        "@parcel/utils": "2.13.3",
+        "@parcel/config-default": "2.14.4",
+        "@parcel/core": "2.14.4",
+        "@parcel/diagnostic": "2.14.4",
+        "@parcel/events": "2.14.4",
+        "@parcel/feature-flags": "2.14.4",
+        "@parcel/fs": "2.14.4",
+        "@parcel/logger": "2.14.4",
+        "@parcel/package-manager": "2.14.4",
+        "@parcel/reporter-cli": "2.14.4",
+        "@parcel/reporter-dev-server": "2.14.4",
+        "@parcel/reporter-tracer": "2.14.4",
+        "@parcel/utils": "2.14.4",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "get-port": "^4.2.0"
@@ -10735,13 +10788,6 @@
         "react-dom": ">= 16.3.0"
       }
     },
-    "node_modules/react-error-overlay": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
-      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/react-full-screen": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/react-full-screen/-/react-full-screen-0.2.5.tgz",
@@ -10851,9 +10897,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
+      "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11664,13 +11710,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/timsort": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "parcel": "^2.8.3",
+    "parcel": "^2.14.4",
     "url": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-url-sync-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Mirador plugin for Harvard mps-viewer which synchronizes the URL with the canvas ID",
   "main": "dist/index.js",
   "source": "src/index.js",


### PR DESCRIPTION
**LTSVIEWER-338 Update Base-x Version**

---

**JIRA Ticket**: [LTSVIEWER-338](https://at-harvard.atlassian.net/browse/LTSVIEWER-338)

# What does this Pull Request do?

- Updates the version of `parcel` in order to update to a more secure version of `base-x`.

# How should this be tested?

- Pull in the latest code from the `LTSVIEWER-338-security-fix` branch
- run `nvm use` to use the correct node version
- If you've worked locally on this plugin before, delete your local `node_modules` folder
- run `npm install`
- You can  run npm list commands to confirm that versions for each package listed as urgent or high in the dependabot alerts are at a version higher than the affected version. For example `npm ls base-x`

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no


[LTSVIEWER-338]: https://at-harvard.atlassian.net/browse/LTSVIEWER-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ