### PR TITLE
LTSVIEWER-339 Switched GHA Runner

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,13 +1,12 @@
 name: Publish to npmjs on release
 on:
-  push: 
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
**LTSVIEWER-339 Switched GHA Runner**

---

**JIRA Ticket**: [LTSVIEWER-339](https://at-harvard.atlassian.net/browse/LTSVIEWER-339)

# What does this Pull Request do?

Switch the runner on the publish package GHA workflow from `huit-arc` to `ubuntu-latest`.

# How should this be tested?

It can only be tested by merging to `main` and creating a new release.
