### PR TITLE
LTSVIEWER-395 Update qs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-url-sync-plugin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-url-sync-plugin",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16795,9 +16795,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lts/mirador-url-sync-plugin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Mirador plugin for Harvard mps-viewer which synchronizes the URL with the canvas ID",
   "main": "dist/index.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,18 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.0",
     "webpack-node-externals": "^3.0.0"
+  },
+  "overrides": {
+    "url": {
+      "qs": "^6.14.1"
+    },
+    "webpack-dev-server": {
+      "qs": {
+        "version": "^6.14.1",
+        "dependencies": {
+          "qs": "^6.14.1"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
**LTSVIEWER-395 Update qs dependency**

---

**JIRA Ticket**: [LTSVIEWER-395](https://at-harvard.atlassian.net/browse/LTSVIEWER-395)

# What does this Pull Request do?
Update version of qs to address [CVE-2025-15284](https://github.com/advisories/GHSA-6rw7-vpxm-498p)

# How should this be tested?
- checkout `LTSVIEWER-395-update-qs` locally
- run `npm i`
- run `npm run serve` and confirm that examples in demo/demoEntry.js are displayed as expected
- run `npm ls qs` and ensure that version(s) is 6.14.1 or above

# Test coverage
Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no

[LTSVIEWER-395]: https://at-harvard.atlassian.net/browse/LTSVIEWER-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ